### PR TITLE
Adjustments to the CfP 2024

### DIFF
--- a/2024-cfp.md
+++ b/2024-cfp.md
@@ -1,29 +1,39 @@
 # Railways and Open Transport Devroom at FOSDEM 2024 - Call for Participation
 
-We are excited to announce that for the second time there will be a **Railways and Open Transport devroom** at FOSDEM, after its [amazing debut in 2023](https://archive.fosdem.org/2023/schedule/track/railways_and_open_transport/). Together, we explore the space of Free and Open Source Software in the context of railways and public transport. We invite you to participate by presenting your work and projects in this space. Once again, this will be excellent opportunity to show what you are doing and discuss it with like-minded people from the community.
+We are excited to announce that for the second time there will be a **Railways and Open Transport devroom** at FOSDEM, after its [well-received debut in 2023](https://archive.fosdem.org/2023/schedule/track/railways_and_open_transport/). Together, we explore the space of Free and Open Source Software in the context of railways and public transport. We invite you to [participate](https://fosdem.org/submit) by presenting your work and projects in this space. Once again, this will be excellent opportunity to show what you are doing and discuss it with like-minded people from the community.
 
 > [!NOTE]
-> [FOSDEM](https://fosdem.org) is Europe's largest gathering of Free and Open Source Software developers and enthusiasts, with thousands of people attending and hundreds of talks taking place each year. FOSDEM 2024 will happen on the weekend of 3-4 February 2024 as an in-person event in Brussels.
+> [FOSDEM](https://fosdem.org) is Europe's largest gathering of Free and Open Source Software developers and enthusiasts, with thousands of people attending and hundreds of talks taking place each year. FOSDEM 2024 will happen on the weekend of 3-4 February 2024 as an in-person event in Brussels at the ULB university.
 
 <figure>
   <img src="img/fosdem-2023-crowd.jpg" alt="Picture from the devroom in 2023">
   <figcaption>The Railways and Open Transport devroom in 2023 was very-well visited</figcaption>
 </figure>
 
-
 ## Key dates
 
 For the Call for Presentations process:
 * 1 December: CfP submission deadline
 * 15 December: Announcement of selected talks
-* 3 February: Railways and Open Transport devroom at FOSDEM, you must be available onsite to present your talk
+* 3 February: Railways and Open Transport devroom at FOSDEM, you must be available onsite to present your talk (tentatively between 10:30 and 14:30 local time)
 
-For the conference itself:
-* FOSDEM 2024 takes place on 3 and 4 February 2024 in Brussels, at the ULB university
-* The Railways and Open Transport devroom will be on Saturday morning, probably 10:30 - 14:30
+## Topics
 
-All times are 00:00 UTC+1 (Europe/Brussels).
+We are interested in presentations on any topic related to Free and Open Source Software in the context of railways and public transport. Possible topics include:
 
+* Dealing with schedules, time tables, live information about trains and public transport
+* Simulation of network behavior, traffic, dispatching, schedules
+* Open approaches to transport interoperability and standards
+* Operation of infrastructure and vehicles, open source in a safety-critical environment
+* Information systems for trains, stations, infrastructure, ...
+* Geo software, mapping, navigation tools
+* Accessibility assistants for travelers
+* Railway games
+* Research topics, AI applications, AR, conversational UI
+* Booking, tickets, travel planning
+* ...
+
+The audience is developers and enthusiasts of Free and Open Source Software. This includes a good number of railway fans and people active in related communities.
 
 ## Submission process
 
@@ -31,7 +41,7 @@ Please submit your proposals at via the [FOSDEM's new conference system](https:/
 
 Important notes:
 * Your on-site availability is required, we do not accept remote presentations.
-* Talk lengths will usually be 20-30 minutes including Q&A, so please adapt your proposal accordingly. If you specifically want to give a shorter talk, please say so in the submission notes.
+* Preferred talk length is 30 minutes including Q&A. We also welcome shorter talks. Please state the length of the talk in the submission notes.
 * The conference language is English.
 
 Here is how you can submit a presentation to our devroom:
@@ -43,7 +53,7 @@ Here is how you can submit a presentation to our devroom:
     2. Select the **Track**: Railways and Open Transport
     3. Add a meaningful **abstract**. We recommend 1-2 paragraphs that shortly explains what you will be talking about and why people should join.
     4. Optionally, you can add a longer **description**. This will also be public once accepted.
-    5. Optionally, you can add **submission notes**. These will only be visible for the organisers and could contain extra wishes.
+    5. Add the length of your session in the **submission notes**. Optionally add any other information. The submission notes will only be visible for the organisers and could contain extra wishes.
     6. You may also add **additional speakers** by putting their email addresses in the box.
     7. Select an **Open Source license** under which the initiative or project you talk about is published.
     8. You may add **extra review material**, only visible to the organisers, e.g. images or a presentation.
@@ -53,22 +63,17 @@ Here is how you can submit a presentation to our devroom:
     1. Upload a **picture** of yourself if you haven't already
     2. Add your **name**
     3. We recommend to add a short **biography**, telling us and the audience a bit more about yourself
-    4. Regarding the availablity, you don't have to add that. Our devroom will be on Saturday morning
+    4. Regarding the availability, you don't have to add that. Our devroom will be on Saturday morning
     5. Click "Submit proposal!" and wait for our response. Thank you!
 
-If you run into issues with your submission, please reach out to us so we can
-assist you. See below for contact details.
-
+If you run into issues with your submission, please reach out to us so we can assist you. See below for contact details.
 
 ## Recordings
 
-The talks are usually recorded on-site. Any recordings will be published under
-the same license as all FOSDEM content (CC-BY-2.0). By agreeing to present in the
-Railways and Open Transport devroom, you automatically give permission to be
-recorded.
-
+The talks are usually recorded on-site. Any recordings will be published under the same license as all FOSDEM content (CC-BY-2.0). By submitting a proposal and agreeing to present in the Railways and Open Transport devroom, you give permission to be recorded.
 
 ## How can I contact you?
 
-You can reach the devroom's coordinators via email:
-`railways-devroom-devroom-manager (at) fosdem.org`
+The organizers of the devroom can be reached by sending email to `railways-devroom-devroom-manager (at) fosdem.org`. Please do not hesitate to contact us if you have any inquiry or suggestion for the devroom.
+
+Max Mehl, Simon Clavier, Cornelius Schumacher, Loic Hamelin, Peter Keller - Railways and Open Transport devroom co-organizers


### PR DESCRIPTION
Here are a couple of suggestions to improve the CfP 2024.

I also adjusted the format to consistently not line break within sentences. When sending this via email some take should be taken that it shows up properly.

It might also be good to rename the file, so that it doesn't provide additional context to understand what it it about. I would suggest to name it `fosdem-devroom-railways-and-open-transport-cfp.md`.